### PR TITLE
remove fxp/composer-asset-plugin from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN set -xe \
   && mv composer.phar /usr/local/bin/composer \
   && which composer \
   && composer --version \
-  && composer global require "fxp/composer-asset-plugin:~1.2" \
   && curl -L http://www.phing.info/get/phing-latest.phar -o /usr/local/bin/phing \
   && chmod +x /usr/local/bin/phing \
   && which phing \


### PR DESCRIPTION
Imho we should not install this plugin for the whole image, since not all projects need this plugin.
Additionally we already had problems whith different plugin versions between project and global installation.

I'm aware that this means a BC break, but this image is really young and not stable by now.
The eralier we remove it, the less impact it will have.