### PR TITLE
Feature/readme pimp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A common task is to run phpunit tests with code coverage:
 job_name:
   image: milchundzucker/php-essentials:5.6
   script:
+    - composer install
     - xdebug on
     - phpunit
   tags:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There are two things you should know upfront:
 
 1. This image was build with **xdebug** but turned it off by default to speed up composer. If you need xdebug 
 (i.e. code coverage with phpunit). You have to call `xdebug on` (and `xdebug off` to deactivate it again) before you run
-somehting which relies on xdebug.
+something which relies on xdebug.
 2. This image was also build with the **uopz** PHP extension, which is also turned off by default. If you need uopz
 (i.e. swizzling code to ease up testing PHP functions such as `header()`), you have to call `uopz on` (and `uopz off` to deactivate
 it again before you can run something which relies on uopz.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ job_name:
 ## What's installed?
 * composer
 * Phing
+* PHP Extensions
+  * opcache
+  * pdo_mysql
+  * soap
+  * ssh2
+* VCS Tools
+  * git
+  * subversion
 * Shims to (de)activate xdebug and uopz
-* ssh2-extension
-* git and subversion CLI
 * rsync and ssh
-* php opcache
-* php SOAP extension
-* php PDO_mysql extension
 * modified SSH client config to accept every host key for `*.milchundzucker.de`


### PR DESCRIPTION
* The change in the example is to show, that you should run `composer install` before `xdebug on`.
* Reordered the PHP-Extension by alphabet.
